### PR TITLE
Github Broker settings update for Kubernetes deployment on Windows

### DIFF
--- a/broker/broker-github-com-deployment.yaml
+++ b/broker/broker-github-com-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: broker-github-com
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      io.kompose.service: broker-github-com
   strategy: {}
   template:
     metadata:


### PR DESCRIPTION
I made the changes to resolve the issues I encountered below:

**\snyk-configs\broker> kubectl apply -f broker-github-com-deployment.yaml,broker-github-com-github-com-env-configmap.yaml**

_configmap/broker-github-com-github-com-env configured
**error: unable to recognize "broker-github-com-deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"**_    

**\snyk-configs\broker> kubectl apply -f broker-github-com-deployment.yaml,broker-github-com-github-com-env-configmap.yaml**

_error: error validating "broker-github-com-deployment.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false_

**\snyk-configs\broker> kubectl apply -f broker-github-com-deployment.yaml,broker-github-com-github-com-env-configmap.yaml**

_error: error validating "broker-github-com-deployment.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=b-com-github-com-env-configmap.yaml --validate=false
The Deployment "broker-github-com" is invalid:
* spec.selector: Required value
* spec.template.metadata.labels: Invalid value: map[string]string{"io.kompose.service":"broker-github-com"}: `selector` does not match template `labels`_